### PR TITLE
Debug admin panel, suggestions, and supabase migration

### DIFF
--- a/supabase/migrations/20250924131000_fix_offers_schema_and_policies.sql
+++ b/supabase/migrations/20250924131000_fix_offers_schema_and_policies.sql
@@ -1,0 +1,95 @@
+/*
+  Align offers schema and admin policies with application code
+
+  - Ensure offers table supports optional campaign link and influencer_card_id
+  - Extend offers.status allowed values used by the app
+  - Keep policies idempotent and avoid duplicate/conflicting ones
+*/
+
+-- Offers schema adjustments
+DO $$
+BEGIN
+  -- Add influencer_card_id if missing
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'offers' AND column_name = 'influencer_card_id'
+  ) THEN
+    ALTER TABLE offers
+      ADD COLUMN influencer_card_id uuid REFERENCES influencer_cards(id) ON DELETE SET NULL;
+  END IF;
+
+  -- Allow campaign_id to be nullable (offers can be created without campaign)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'offers' AND column_name = 'campaign_id' AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE offers ALTER COLUMN campaign_id DROP NOT NULL;
+  END IF;
+
+  -- Normalize details column default to jsonb if needed
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'offers' AND column_name = 'details'
+  ) THEN
+    ALTER TABLE offers ALTER COLUMN details SET DEFAULT '{}'::jsonb;
+  END IF;
+
+  -- Replace status check constraint with the set used by the app
+  -- Drop any existing CHECK on offers.status
+  PERFORM (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY (c.conkey)
+    WHERE t.relname = 'offers' AND a.attname = 'status' AND c.contype = 'c'
+  );
+
+  FOR SELECT conname FROM pg_constraint c
+      JOIN pg_class t ON t.oid = c.conrelid
+      WHERE t.relname = 'offers' AND c.contype = 'c'
+  INTO STRICT conname
+  LOOP
+    EXECUTE format('ALTER TABLE offers DROP CONSTRAINT IF EXISTS %I', conname);
+  END LOOP;
+
+  -- Add new explicit constraint name to make future updates easier
+  ALTER TABLE offers
+    ADD CONSTRAINT offers_status_check
+    CHECK (status IN ('pending','accepted','declined','in_progress','completed','terminated','cancelled'));
+END $$;
+
+-- RLS policy cleanup for user blocking (no-op if already applied by previous migrations)
+DO $$
+BEGIN
+  -- Ensure base user self-update policy exists
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'user_profiles' AND policyname = 'users_can_update_own_profile'
+  ) THEN
+    CREATE POLICY "users_can_update_own_profile"
+      ON user_profiles FOR UPDATE TO authenticated
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+  END IF;
+
+  -- Ensure admins/moderators can manage other users (prevent self-blocking)
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'user_profiles' AND policyname = 'admin_moderator_can_manage_users'
+  ) THEN
+    CREATE POLICY "admin_moderator_can_manage_users"
+      ON user_profiles FOR UPDATE TO authenticated
+      USING (
+        user_id != auth.uid() AND EXISTS (
+          SELECT 1 FROM user_profiles up
+          WHERE up.user_id = auth.uid() AND up.role IN ('admin','moderator') AND up.is_deleted = false
+        )
+      )
+      WITH CHECK (
+        user_id != auth.uid() AND EXISTS (
+          SELECT 1 FROM user_profiles up
+          WHERE up.user_id = auth.uid() AND up.role IN ('admin','moderator') AND up.is_deleted = false
+        )
+      );
+  END IF;
+END $$;
+

--- a/supabase/migrations/20250924131500_update_admin_policies_use_function.sql
+++ b/supabase/migrations/20250924131500_update_admin_policies_use_function.sql
@@ -1,0 +1,35 @@
+/*
+  Use get_user_role() in admin policies to respect assignments in user_roles
+*/
+
+DO $$
+BEGIN
+  -- Drop if present to avoid duplicate-name errors, then recreate
+  IF EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'user_profiles' AND policyname = 'admin_moderator_can_manage_users'
+  ) THEN
+    DROP POLICY "admin_moderator_can_manage_users" ON user_profiles;
+  END IF;
+
+  CREATE POLICY "admin_moderator_can_manage_users"
+    ON user_profiles FOR UPDATE TO authenticated
+    USING (
+      user_id != auth.uid() AND get_user_role(auth.uid()) IN ('moderator','admin')
+    )
+    WITH CHECK (
+      user_id != auth.uid() AND get_user_role(auth.uid()) IN ('moderator','admin')
+    );
+
+  -- Ensure admin self-update policy remains intact for admins editing their own non-blocking fields
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE schemaname = 'public' AND tablename = 'user_profiles' AND policyname = 'admin_can_update_own_profile'
+  ) THEN
+    CREATE POLICY "admin_can_update_own_profile"
+      ON user_profiles FOR UPDATE TO authenticated
+      USING (user_id = auth.uid() AND get_user_role(auth.uid()) = 'admin')
+      WITH CHECK (user_id = auth.uid() AND get_user_role(auth.uid()) = 'admin');
+  END IF;
+END $$;
+


### PR DESCRIPTION
Fix Supabase migration errors, align `offers` table schema, and update RLS policies to enable admin panel user management and correct offers display.

The admin panel's user blocking functionality was broken due to RLS policies not correctly evaluating user roles. The offers section appeared empty because the database schema's `status` constraint and `campaign_id` nullability did not match the application's expectations. These changes introduce idempotent migrations to resolve these schema and policy discrepancies.

---
<a href="https://cursor.com/background-agent?bcId=bc-9880614e-82d4-4f61-889d-9877f7c0a005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9880614e-82d4-4f61-889d-9877f7c0a005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

